### PR TITLE
Use pacsort instead of sort for the package index

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -198,7 +198,7 @@ repo_packages_index() {
 	local TMPINDEX="$1/.index.0.xz"
 
 	rm -f "$TMPINDEX"
-	find "$1" -name "*$PKGEXT" -printf '%f\n'|sed 's/.\{'${#PKGEXT}'\}$//'|sort|xz -9 > "$TMPINDEX"
+	find "$1" -name "*$PKGEXT" -printf '%f\n'|sed 's/.\{'${#PKGEXT}'\}$//'|pacsort|xz -9 > "$TMPINDEX"
 	if [[ ! -e "$INDEX" ]]; then
 	  mv "$TMPINDEX" "$INDEX"
 	elif diff -q "$INDEX" "$TMPINDEX"; then


### PR DESCRIPTION
 pacsort is required to list packages in the right order.

 Example: `agetpkg  -l '^linux$' |tail`

 Before:
 linux 4.3.2-1 x86_64
 linux 4.3.3-1 x86_64
 linux 4.3.3-2 x86_64
 linux 4.3.3-3 x86_64
 linux 4.4.1-1 x86_64
 linux 4.4.1-2 x86_64
 linux 4.4-1 x86_64
 linux 4.4-2 x86_64
 linux 4.4-3 x86_64
 linux 4.4-4 x86_64

 After:
 linux 4.3.2-1 x86_64
 linux 4.3.3-1 x86_64
 linux 4.3.3-2 x86_64
 linux 4.3.3-3 x86_64
 linux 4.4-1 x86_64
 linux 4.4-2 x86_64
 linux 4.4-3 x86_64
 linux 4.4-4 x86_64
 linux 4.4.1-1 x86_64
 linux 4.4.1-2 x86_64

Signed-off-by: Mohammad AlSaleh CE.Mohammad.AlSaleh@gmail.com
