### PR TITLE
archive.sh should have non-zero exit code on rsync failures

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -235,6 +235,8 @@ iso_rsync() {
 main() {
 	# more verbose when launched from a tty
 	[[ -t 1 && -n "$DEBUG" ]] && set -x
+	
+	local EXIT_CODE=0
 
 	load_config
 
@@ -262,13 +264,16 @@ main() {
 			# last pointing to an empty repo.
 			(( $REPO_DAYLY )) && repo_daily
 			(( $REPO_PACKAGES )) && repo_packages
+		else
+			EXIT_CODE=1
 		fi
 
 	fi
 
 	(( $ARCHIVE_ISO )) && iso_rsync
+	EXIT_CODE=$(( $EXIT_CODE + $? ))
 
-	return 0
+	return $EXIT_CODE
 }
 
 main "$@"


### PR DESCRIPTION
I would only consider a run of `archive.sh` successful if it successfully syncs all the stuff that it was supposed to.